### PR TITLE
add country to firstboot

### DIFF
--- a/distributions/Lakka/config/firstboot.sh
+++ b/distributions/Lakka/config/firstboot.sh
@@ -20,6 +20,7 @@ END
 # setup network
 SSID=""
 PSK=""
+COUNTRY=""
 
 [ -f ${wifi_cfg} ] && . ${wifi_cfg}
 
@@ -40,6 +41,10 @@ sleep 5
 echo "${PSK}"
 ) | connmanctl
 END
+fi
+
+if [ -n "${COUNTRY}" ]; then
+  iw reg set ${COUNTRY}
 fi
 
 # apply RetroArch overrides to default configuration

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -364,8 +364,10 @@ if [ -f "${DISTRO_DIR}/${DISTRO}/config/firstboot.sh" ]; then
 # Uncomment following lines and set your Wi-Fi name (SSID) and password (PSK) below.
 # SSID/PSK must not inlcude space / quotes / special character. If you have to use
 # them, escape them and hope for best.
+# COUNTRY is an optional field, which sets the Wi-Fi adapter country. The value should follow ISO/IEC 3166-1 alpha2.
 #SSID=
 #PSK=
+#COUNTRY=
 EOF
   mcopy "${LE_TMP}/wifi-config.txt" ::/wifi-config.txt >"${SAVE_ERROR}" 2>&1 || show_error
 


### PR DESCRIPTION
This PR adds the country variable to wifi-config.txt, which gets set by `iw reg set $COUNTRY`  
It is a good idea to set the wifi country, this makes sure the wifi adapter sends on (all) allowed frequencies, which leads to the best wireless communication possible.
